### PR TITLE
Fixed one error with non-alpha-numeric characters.  Added 3 options.  Updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ Valid parameters:
 - *align_middle*: set to false to disable vertical alignment behavior
 - *align_center*: set to false to disable centering behavior (horizontal)
 - *multiline*: set to true to allow the text to wrap
+- *width*: set this to avoid the need to set the width of the element before calling boxfit on it
+- *height*: set this to avoid the need to set the height of the element before calling boxfit on it
+- *maxFontSize*: set to the max font size you want for the element, if none is given there is no maximum
 
 Notice
 ======

--- a/jquery.boxfit.js
+++ b/jquery.boxfit.js
@@ -20,17 +20,37 @@
         if (!settings.multiline) {
             $(this).css('white-space', 'nowrap');
         }
+
         original_text = $(this).html();
         $(this).html("");
-        original_width = $(this).width();
-        original_height = $(this).height();
+        
+        if(settings.width !== undefined) {
+            original_width = settings.width;
+            $(this).width(original_width + "px");
+        }
+        else {
+            original_width = $(this).width();
+        }
+        
+        if(settings.height !== undefined) {
+            original_height = settings.height;
+            $(this).height(original_height + "px");
+        }
+        else {
+            original_height = $(this).height();
+        }
+
+        if(settings.maxFontSize !== undefined) {
+            settings.maxFont = true;
+        }
+
         if (!original_width || !original_height) {
             if (window.console != null) {
                 console.info('Set static height/width on target DIV before using boxfit!');
             }
             return $(this).html(original_text);
         } else {
-            if ($(original_text).find("span.boxfitted").length === 0) {
+            if ($("<div>" + original_text + "</div>").find("span.boxfitted").length === 0) {
                 span = $("<span></span>").addClass("boxfitted").html(original_text);
                 $(this).html(span);
             } else {


### PR DESCRIPTION
...lement had non-alpha-numeric characters in it.  For example calling box fit on <div>@$(*Y!@#$%</div> would raise this error : "Uncaught Error: Syntax error, unrecognized expression: ( jquery.js:4267"

Added maxFontSize (needed this several times in my project) and options for setting width/height in the options instead of on the element before hand.

Updated README to account for new settings.
