### PR TITLE
reset display so measurements are correct

### DIFF
--- a/dist/jquery.boxfit.js
+++ b/dist/jquery.boxfit.js
@@ -46,6 +46,9 @@
         line_height:'100%' 
       };
       $.extend(settings, options);
+      
+      // reset display so measurements are correct
+      $(this).css('display', 'block');
 
       // take measurements
       if (settings.width) {

--- a/src/jquery.boxfit.js
+++ b/src/jquery.boxfit.js
@@ -46,6 +46,9 @@
         line_height:'100%' 
       };
       $.extend(settings, options);
+      
+      // reset display so measurements are correct
+      $(this).css('display', 'block');
 
       // take measurements
       if (settings.width) {


### PR DESCRIPTION
If you're running boxfit on resize, it's necessary to reset the display back to block so measurements are obtained correctly.
